### PR TITLE
loading intel ucode using systemd-boot

### DIFF
--- a/installer/install-arch
+++ b/installer/install-arch
@@ -96,6 +96,7 @@ EOF
 cat <<EOF > /mnt/boot/loader/entries/arch.conf
 title    Arch Linux
 linux    /vmlinuz-linux
+initrd	 /intel-ucode.img
 initrd   /initramfs-linux.img
 options  root=PARTUUID=$(blkid -s PARTUUID -o value "$part_root") rw
 EOF

--- a/installer/install-arch
+++ b/installer/install-arch
@@ -96,7 +96,7 @@ EOF
 cat <<EOF > /mnt/boot/loader/entries/arch.conf
 title    Arch Linux
 linux    /vmlinuz-linux
-initrd	 /intel-ucode.img
+initrd   /intel-ucode.img
 initrd   /initramfs-linux.img
 options  root=PARTUUID=$(blkid -s PARTUUID -o value "$part_root") rw
 EOF


### PR DESCRIPTION
I think since you are [pacstraping](https://github.com/mdaffin/arch-pkgs/blob/8b5b4f68565368274b733e24d3c66226c7aaf71c/installer/install-arch#L80) the mdaffin-desktop package in the installer script, which contains [intel-ucode](https://github.com/mdaffin/arch-pkgs/blob/8b5b4f68565368274b733e24d3c66226c7aaf71c/pkg/mdaffin/base/PKGBUILD#L17) package, it needs to be loaded using systemd-boot by adding its entry in arch.conf. According to [systemd-boot](https://wiki.archlinux.org/index.php/Microcode#systemd-boot).